### PR TITLE
Update allowed OSPF area ID formats

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ locals {
       ),
     ])
     ospf                                    = lookup(l3out, "ospf", null) != null ? true : false
-    ospf_area                               = try(tonumber(lookup(lookup(l3out, "ospf", {}), "area", "backbone")), false) != false ? "0.0.0.${tonumber(lookup(lookup(l3out, "ospf", {}), "area", "backbone"))}" : "backbone"
+    ospf_area                               = lookup(lookup(l3out, "ospf", {}), "area", "backbone")
     ospf_area_cost                          = lookup(lookup(l3out, "ospf", {}), "area_cost", local.defaults.apic.tenants.l3outs.ospf.area_cost)
     ospf_area_type                          = lookup(lookup(l3out, "ospf", {}), "area_type", local.defaults.apic.tenants.l3outs.ospf.area_type)
     l3_multicast_ipv4                       = lookup(l3out, "l3_multicast_ipv4", local.defaults.apic.tenants.l3outs.l3_multicast_ipv4)


### PR DESCRIPTION
There are issues with the Tenant L3Out OSPF area ID in modules 'tenant' and 'aci-l3out'. In this module, the area ID is modified as:

````
ospf_area = try(tonumber(lookup(lookup(l3out, "ospf", {}), "area", "backbone")), false) != false ? "0.0.0.${tonumber(lookup(lookup(l3out, "ospf", {}), "area", "backbone"))}" : "backbone"
````
1. This does not allow to specify the OSPF area ID in the IP address format. Example:
````
      l3outs:
        - name: MY_L3Out_W02_CN
          ospf:
            area: 0.0.0.50
            area_type: nssa
```` 
Because the `tonumber` type conversion function fails, and `ospf_area` is incorrectly set to `backbone`:
````
> try(tonumber("0.0.0.50"), false)
false
````
2. If the area ID is a number > 256, e.g. `257`, it is incorrectly converted to e.g. `0.0.0.257` instead of `0.0.1.1`.

3. The `ospf_area` variable validation in module 'aci_l3out' does not allow a number but only `backbone` or an ID in IP address format.

PR #10 of module 'aci-l3out' proposes to extend the validation to allow numbers too. When it has been changed, the above `ospf_area` definition can be simplified as requested here:

````
ospf_area = lookup(lookup(l3out, "ospf", {}), "area", "backbone")
````