### PR TITLE
Enable BGP when bgp_peers are defined under node_profiles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -173,6 +173,9 @@ locals {
     domain      = "${l3out.domain}${local.defaults.apic.access_policies.routed_domains.name_suffix}"
     vrf         = "${l3out.vrf}${local.defaults.apic.tenants.vrfs.name_suffix}"
     bgp = anytrue([
+      anytrue([
+        for np in try(l3out.node_profiles, []) : try(np.bgp_peers, null) != null
+      ]),
       anytrue(
         flatten([for np in try(l3out.node_profiles, []) : [
           for ip in try(np.interface_profiles, []) : [
@@ -180,6 +183,7 @@ locals {
           ]
         ]])
       ),
+      try(l3out.bgp_peers, null) != null,
       anytrue(
         flatten([for node in try(l3out.nodes, []) : [
           for int in try(node.interfaces, []) : try(int.bgp_peers, null) != null


### PR DESCRIPTION
## Description

BGP is not enabled under an L3Out (i.e. MO bgpExtP is not created under MO l3extOut) when `bgp_peers` is defined under the following locations:
* `apic.tenants.l3outs.node_profiles`
* `apic.tenants.l3outs`

The current code creates bgpExtP only when `bgp_peers` is defined under the following locations:
* `apic.tenants.l3outs.node_profiles.interface_profiles.interfaces`
* `apic.tenants.l3outs.nodes.interfaces`


## Fix

During the local variable definition (`local.l3outs.bgp`), check `bgp_peers` under the two locations mentioned above.
